### PR TITLE
Rename helm mixin to helm2

### DIFF
--- a/vanity/content/code/mixin/helm.md
+++ b/vanity/content/code/mixin/helm.md
@@ -1,5 +1,5 @@
 ---
-title: "helm mixin"
-vanity: "https://github.com/getporter/helm-mixin"
-url: "/mixin/helm/"
+title: "helm2 mixin"
+vanity: "https://github.com/getporter/helm2-mixin"
+url: "/mixin/helm2/"
 ---


### PR DESCRIPTION
Per https://github.com/getporter/helm-mixin/issues/81 we are renaming the helm mixin to helm2.