### PR TITLE
Add example-bundles repository

### DIFF
--- a/vanity/content/code/example-bundles.md
+++ b/vanity/content/code/example-bundles.md
@@ -1,0 +1,6 @@
+---
+title: "example-bundles"
+weight: 130
+vanity: "https://github.com/getporter/example-bundles"
+url: "/example-bundles/"
+---


### PR DESCRIPTION
Add the example-bundles repository to our vanity Go server under get.porter.sh/example-bundles
